### PR TITLE
INFO cmd getting chopped on very small data windows.

### DIFF
--- a/src/transport.ts
+++ b/src/transport.ts
@@ -141,10 +141,8 @@ export class WSTransport {
                     transport.handlers.messageHandler(me);
                 } else {
                     connected = true;
-                    resolve(transport);
-                    setTimeout(function () {
-                        transport.handlers.messageHandler(me);
-                    }, 0);
+                    resolve(transport)
+                    transport.handlers.messageHandler(me)
                 }
             };
         });


### PR DESCRIPTION
- fixed initial info processing, rather than execute on a timeout - if the server is sending very small data windows, the invocation could happen before the first window is processed.