### PR TITLE
Breaking Change: renamed SubscribeOptions to SubscriptionOptions

### DIFF
--- a/src/nats.ts
+++ b/src/nats.ts
@@ -70,7 +70,7 @@ export interface ClientEventMap {
     error: ErrorCallback;
 }
 
-export interface SubscribeOptions {
+export interface SubscriptionOptions {
     queue?: string;
     max?: number;
 }
@@ -147,7 +147,7 @@ export class NatsConnection implements ClientHandlers {
     }
 
 
-    subscribe(subject: string, cb: MsgCallback, opts: SubscribeOptions = {}): Promise<Subscription> {
+    subscribe(subject: string, cb: MsgCallback, opts: SubscriptionOptions = {}): Promise<Subscription> {
         return new Promise<Subscription>((resolve, reject) => {
             if (this.isClosed()) {
                 reject(NatsError.errorForCode(ErrorCode.CONNECTION_CLOSED))

--- a/test/basics.ts
+++ b/test/basics.ts
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import {connect, Msg, Payload, SubscribeOptions} from "../src/nats"
+import {connect, Msg, Payload, SubscriptionOptions} from "../src/nats"
 import test from "ava"
 import {WSTransport} from "../src/transport"
 import {Lock} from "./helpers/latch"
@@ -456,7 +456,7 @@ test('subscription timeout with count is autocancel', async (t) => {
 
     let subj = nuid.next();
     let sub = await nc.subscribe(subj, () => {
-    }, {max: 2} as SubscribeOptions);
+    }, {max: 2} as SubscriptionOptions);
     sub.setTimeout(500, () => {
         t.fail("didn't get expected message count");
     });
@@ -481,7 +481,7 @@ test('subscription cancel timeout', async (t) => {
         if (sub.hasTimeout()) {
             sub.cancelTimeout();
         }
-    }, {max: 2} as SubscribeOptions);
+    }, {max: 2} as SubscriptionOptions);
     sub.setTimeout(500, () => {
         t.fail('timeout fired');
     });


### PR DESCRIPTION
Fixed ill-named `SubscribeOptions` to `SubscriptionOptions` to match other clients.