### PR TITLE
updating dependencies from nats-base-client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,15 @@
 # Logs
 npm-debug.log*
+.DS_STORE
 
 # generated files
 build/
 .idea/
-.certs/
+certs/
 srv/
+
+nats-server
+nats.mjs
 
 # nyc test coverage
 .nyc_output

--- a/nats.d.ts
+++ b/nats.d.ts
@@ -52,7 +52,7 @@ export interface ConnectionOptions {
   reconnectTimeWait?: number;
   servers?: Array<string> | string;
   timeout?: number;
-  tls?: boolean | TlsOptions;
+  tls?: TlsOptions;
   token?: string;
   user?: string;
   verbose?: boolean;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nats.ws",
-  "version": "1.0.0-87",
+  "version": "1.0.0-90",
   "description": "WebSocket NATS client",
   "main": "nats.mjs",
   "types": "nats.d.ts",

--- a/src/nats-base-client.ts
+++ b/src/nats-base-client.ts
@@ -12,9 +12,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export * from "https://raw.githubusercontent.com/nats-io/nats.deno/main/nats-base-client/internal_mod.ts";
+export * from "https://raw.githubusercontent.com/nats-io/nats.deno/v0.1.1-31/nats-base-client/internal_mod.ts";
 
-import { ConnectionOptions as CO } from "https://raw.githubusercontent.com/nats-io/nats.deno/main/nats-base-client/internal_mod.ts";
+import { ConnectionOptions as CO } from "https://raw.githubusercontent.com/nats-io/nats.deno/v0.1.1-31/nats-base-client/internal_mod.ts";
 
 export interface ConnectionOptions extends CO {
   ws?: boolean;

--- a/src/ws_transport.ts
+++ b/src/ws_transport.ts
@@ -19,11 +19,11 @@ import {
   Transport,
   Deferred,
   deferred,
-} from "https://deno.land/x/nats@v0.1.1-19/nats-base-client/internal_mod.ts";
+} from "./nats-base-client.ts";
 
 import { ConnectionOptions } from "./nats-base-client.ts";
 
-const VERSION = "1.0.0-50";
+const VERSION = "1.0.0-90";
 const LANG = "nats.ws";
 
 export class WsTransport implements Transport {


### PR DESCRIPTION
- clamped nats-base-client dependency.
- bumped versions for next npm release
- [breaking] the `tls` option was defined as `boolean` or `TLSOptions` - all arguments are now optional, and presence indicates desire for TLS.