### PR TITLE
updates nats-base-client to v1.0.0-5

### DIFF
--- a/nats.d.ts
+++ b/nats.d.ts
@@ -124,7 +124,7 @@ export interface Msg {
   reply?: string;
   data: Uint8Array;
   headers?: MsgHdrs;
-  respond(data?: Uint8Array, headers?: MsgHdrs): boolean;
+  respond(data?: Uint8Array, opts?: PublishOptions): boolean;
 }
 
 export interface MsgHdrs extends Iterable<[string, string[]]> {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nats.ws",
-  "version": "1.0.0-104",
+  "version": "1.0.0-105",
   "description": "WebSocket NATS client",
   "main": "nats.mjs",
   "types": "nats.d.ts",

--- a/src/nats-base-client.ts
+++ b/src/nats-base-client.ts
@@ -12,9 +12,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export * from "https://raw.githubusercontent.com/nats-io/nats.deno/v1.0.0-4/nats-base-client/internal_mod.ts";
+export * from "https://raw.githubusercontent.com/nats-io/nats.deno/v1.0.0-5/nats-base-client/internal_mod.ts";
 
-import { ConnectionOptions as CO } from "https://raw.githubusercontent.com/nats-io/nats.deno/v1.0.0-4/nats-base-client/internal_mod.ts";
+import { ConnectionOptions as CO } from "https://raw.githubusercontent.com/nats-io/nats.deno/v1.0.0-5/nats-base-client/internal_mod.ts";
 
 export interface ConnectionOptions extends CO {
   ws?: boolean;

--- a/src/ws_transport.ts
+++ b/src/ws_transport.ts
@@ -24,7 +24,7 @@ import {
 
 import { ConnectionOptions } from "./nats-base-client.ts";
 
-const VERSION = "1.0.0-104";
+const VERSION = "1.0.0-105";
 const LANG = "nats.ws";
 
 export class WsTransport implements Transport {


### PR DESCRIPTION
- [chore] bumped nats-base-client to v1.0.0-5
- [breaking] - nbc@v1.0.0-5 changes the signature of respond from `(payload?:Uint8Array, headers?:MsgHdrs): boolean` to `(payload?:Uint8Array, opts?: PublishOptions): boolean` - headers are now specified in the `PublishOptions`.