### PR TITLE
support full websocket URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,13 +79,16 @@ By default, the nats-server will serve WSS connections only.
 
 The `nats-server` gossips cluster configuration to clients. Cluster
 configuration however is disseminated as `host:port`. With websockets, 
-a connection is made using an URL which means that it sports an URL. By default,
+a connection is made using an URL which means that the protocol specifies
+whether the connection is encrypted or not. By default,
 the nats.ws client assumes any specified `host:port` is available
 via `wss://host:port`.
 
-If your cluster is not uniform (`ws://` or `wss://` only, 
+If your cluster security not uniform (mixes `ws://` and `wss://`), 
 you'll need to disable server advertising or on the client specify 
-the `ignoreServerUpdates` connection option. 
+the `ignoreServerUpdates` connection option. Of course in this case
+you are responsible for providing all the URLs for the cluster if
+you want fail over. 
 
 
 ```typescript

--- a/README.md
+++ b/README.md
@@ -76,28 +76,33 @@ can reference it from your code:
 ## Connection Options Specific to nats.ws
 
 By default, the nats-server will serve WSS connections only.
-The current architecture of nats.deno and nats.ws will soon be
-removing the `url` connection field in favor of `servers`.
 
-There are two reasons for this change. First, URL embedded authentication
-credentials are not globally supported in non HTTP/S protocols.
+The `nats-server` gossips cluster configuration to clients. Cluster
+configuration however is disseminated as `host:port`. With websockets, 
+a connection is made using an URL which means that it sports an URL. By default,
+the nats.ws client assumes any specified `host:port` is available
+via `wss://host:port`.
 
-Secondly, connection protocols are not gossiped on cluster information. 
-To specify a `ws://`  connection, the connection option `ws` must be set to `true`.
-Otherwise the client will always attempt to connect via `wss://`
+If your cluster is not uniform (`ws://` or `wss://` only, 
+you'll need to disable server advertising or on the client specify 
+the `ignoreServerUpdates` connection option. 
 
 
 ```typescript
-  // connects via ws://
+  
   const conn = await connect(
-    { servers: "localhost:9222", ws: true },
+    { servers: ["ws://localhost:9222", "wss://localhost:2229", "localhost:9111"] },
   );
 
-  // connects via wss://
-  const wssConn = await connect(
-    { servers: "localhost:9222"}
-  )
 ```
+
+In the above example, the first two URLs connect as per their protocol specifications.
+The third server connects using `wss://` as that is the default.
+
+If you are accessing websocket via a proxy, likely the `ignoreServerUpdates` should
+be specified to avoid learning about servers that are not accessible from
+the outside.
+
 
 ## Web Application Examples
 

--- a/examples/bench.js
+++ b/examples/bench.js
@@ -52,7 +52,12 @@ function updateResults(s) {
 async function run() {
   const server = getString("server");
   const ws = isChecked("ws");
-  const nc = await connect({ servers: server, ws: ws, pendingLimit: 8192 });
+  const nc = await connect(
+    {
+      servers: `${ws ? "ws://" : "wss://"}${server}`,
+      pendingLimit: 8192,
+    },
+  );
   nc.closed()
     .then((err) => {
       if (err) {

--- a/examples/chat.js
+++ b/examples/chat.js
@@ -30,7 +30,7 @@ const init = async function () {
   // a real app would allow configuring the hostport and whether
   // to use WSS or not.
   const conn = await connect(
-    { servers: "localhost:9222", ws: true },
+    { servers: "ws://localhost:9222" },
   );
 
   // handle connection to the server is closed - should disable the ui

--- a/examples/simple.html
+++ b/examples/simple.html
@@ -24,7 +24,7 @@
 
   const init = async function () {
     // create a connection
-    const nc = await connect({ servers: 'localhost:9222', ws: true })
+    const nc = await connect({ servers: 'ws://localhost:9222' })
     addEntry('connected to NATS!');
 
     // simple publisher

--- a/nats.d.ts
+++ b/nats.d.ts
@@ -62,7 +62,6 @@ export interface ConnectionOptions {
   user?: string;
   verbose?: boolean;
   waitOnFirstConnect?: boolean;
-  ws?: boolean;
 }
 
 export interface TlsOptions {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "nats.ws",
-  "version": "1.0.0-106",
+  "version": "1.0.0-108",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nats.ws",
-  "version": "1.0.0-108",
+  "version": "1.0.0-110",
   "description": "WebSocket NATS client",
   "main": "nats.mjs",
   "types": "nats.d.ts",

--- a/src/nats-base-client.ts
+++ b/src/nats-base-client.ts
@@ -12,10 +12,4 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export * from "https://raw.githubusercontent.com/nats-io/nats.deno/v1.0.0-7/nats-base-client/internal_mod.ts";
-
-import type { ConnectionOptions as CO } from "https://raw.githubusercontent.com/nats-io/nats.deno/v1.0.0-7/nats-base-client/internal_mod.ts";
-
-export interface ConnectionOptions extends CO {
-  ws?: boolean;
-}
+export * from "https://raw.githubusercontent.com/nats-io/nats.deno/ws-url/nats-base-client/internal_mod.ts";

--- a/src/nats-base-client.ts
+++ b/src/nats-base-client.ts
@@ -12,4 +12,4 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export * from "https://raw.githubusercontent.com/nats-io/nats.deno/ws-url/nats-base-client/internal_mod.ts";
+export * from "https://raw.githubusercontent.com/nats-io/nats.deno/main/nats-base-client/internal_mod.ts";

--- a/test/auth.js
+++ b/test/auth.js
@@ -45,7 +45,7 @@ test("auth - none", async (t) => {
   t.plan(1);
   const ns = await NatsServer.start(conf);
   try {
-    const nc = await connect({ port: ns.websocket, ws: true });
+    const nc = await connect({ servers: `ws://127.0.0.1:${ns.websocket}` });
     await nc.close();
     t.fail("shouldnt have been able to connect");
   } catch (ex) {
@@ -59,7 +59,7 @@ test("auth - bad", async (t) => {
   const ns = await NatsServer.start(conf);
   try {
     const nc = await connect(
-      { port: ns.websocket, user: "me", pass: "hello", ws: true },
+      { servers: `ws://127.0.0.1:${ns.websocket}`, user: "me", pass: "hello" },
     );
     await nc.close();
     t.fail("shouldnt have been able to connect");
@@ -73,7 +73,11 @@ test("auth - un/pw", async (t) => {
   t.plan(1);
   const ns = await NatsServer.start(conf);
   const nc = await connect(
-    { port: ns.websocket, user: "derek", pass: "foobar", ws: true },
+    {
+      servers: `ws://127.0.0.1:${ns.websocket}`,
+      user: "derek",
+      pass: "foobar",
+    },
   );
   await nc.flush();
   await nc.close();
@@ -86,7 +90,11 @@ test("auth - sub permissions", async (t) => {
   const ns = await NatsServer.start(conf);
   const lock = Lock(2);
   const nc = await connect(
-    { port: ns.websocket, user: "derek", pass: "foobar", ws: true },
+    {
+      servers: `ws://127.0.0.1:${ns.websocket}`,
+      user: "derek",
+      pass: "foobar",
+    },
   );
   nc.closed().then((err) => {
     t.is(err.code, ErrorCode.PERMISSIONS_VIOLATION);
@@ -112,7 +120,11 @@ test("auth - pub perm", async (t) => {
   const ns = await NatsServer.start(conf);
   const lock = Lock();
   const nc = await connect(
-    { port: ns.websocket, user: "derek", pass: "foobar", ws: true },
+    {
+      servers: `ws://127.0.0.1:${ns.websocket}`,
+      user: "derek",
+      pass: "foobar",
+    },
   );
   nc.closed().then((err) => {
     t.is(err.code, ErrorCode.PERMISSIONS_VIOLATION);
@@ -135,7 +147,7 @@ test("auth - pub perm", async (t) => {
 
 test("auth - user and token is rejected", async (t) => {
   connect(
-    { servers: "127.0.0.1:4222", user: "derek", token: "foobar", ws: true },
+    { servers: "ws://127.0.0.1:4222", user: "derek", token: "foobar" },
   )
     .then(async (nc) => {
       await nc.close();
@@ -150,7 +162,9 @@ test("auth - token", async (t) => {
   const ns = await NatsServer.start(
     Object.assign({ authorization: { token: "foo" } }, wsConfig()),
   );
-  const nc = await connect({ port: ns.websocket, token: "foo", ws: true });
+  const nc = await connect(
+    { servers: `ws://127.0.0.1:${ns.websocket}`, token: "foo" },
+  );
   await nc.flush();
   await nc.close();
   await ns.stop();
@@ -171,7 +185,10 @@ test("auth - nkey", async (t) => {
   }, wsConfig());
   const ns = await NatsServer.start(conf);
   const nc = await connect(
-    { port: ns.websocket, authenticator: nkeyAuthenticator(seed), ws: true },
+    {
+      servers: `ws://127.0.0.1:${ns.websocket}`,
+      authenticator: nkeyAuthenticator(seed),
+    },
   );
   await nc.flush();
   await nc.close();
@@ -205,9 +222,8 @@ test("auth - creds", async (t) => {
   const ns = await NatsServer.start(conf);
   const nc = await connect(
     {
-      port: ns.websocket,
+      servers: `ws://127.0.0.1:${ns.websocket}`,
       authenticator: credsAuthenticator(new TextEncoder().encode(creds)),
-      ws: true,
     },
   );
   await nc.flush();
@@ -241,9 +257,8 @@ test("auth - custom", async (t) => {
   };
   const nc = await connect(
     {
-      port: ns.websocket,
+      servers: `ws://127.0.0.1:${ns.websocket}`,
       authenticator: authenticator,
-      ws: true,
     },
   );
   await nc.flush();
@@ -269,9 +284,8 @@ test("auth - jwt", async (t) => {
   const ns = await NatsServer.start(conf);
   const nc = await connect(
     {
-      port: ns.websocket,
+      servers: `ws://127.0.0.1:${ns.websocket}`,
       authenticator: jwtAuthenticator(jwt, new TextEncoder().encode(useed)),
-      ws: true,
     },
   );
   await nc.flush();
@@ -288,10 +302,9 @@ test("auth - custom error", async (t) => {
   };
   await connect(
     {
-      port: ns.websocket,
+      servers: `ws://127.0.0.1:${ns.websocket}`,
       maxReconnectAttempts: 1,
       authenticator: authenticator,
-      ws: true,
     },
   ).then(() => {
     t.fail("shouldn't have connected");

--- a/test/autounsub.js
+++ b/test/autounsub.js
@@ -21,7 +21,7 @@ const { NatsServer, wsConfig } = require("./helpers/launcher");
 
 test("autounsub - max option", async (t) => {
   const ns = await NatsServer.start(wsConfig());
-  const nc = await connect({ port: ns.websocket, ws: true });
+  const nc = await connect({ servers: `ws://127.0.0.1:${ns.websocket}` });
 
   const subj = createInbox();
   const sub = nc.subscribe(subj, { max: 10 });
@@ -37,7 +37,7 @@ test("autounsub - max option", async (t) => {
 
 test("autounsub - unsubscribe", async (t) => {
   const ns = await NatsServer.start(wsConfig());
-  const nc = await connect({ port: ns.websocket, ws: true });
+  const nc = await connect({ servers: `ws://127.0.0.1:${ns.websocket}` });
 
   const subj = createInbox();
   const sub = nc.subscribe(subj, { max: 10 });
@@ -54,7 +54,7 @@ test("autounsub - unsubscribe", async (t) => {
 
 test("autounsub - can unsub from auto-unsubscribed", async (t) => {
   const ns = await NatsServer.start(wsConfig());
-  const nc = await connect({ port: ns.websocket, ws: true });
+  const nc = await connect({ servers: `ws://127.0.0.1:${ns.websocket}` });
 
   const subj = createInbox();
   const sub = nc.subscribe(subj, { max: 1 });
@@ -71,7 +71,7 @@ test("autounsub - can unsub from auto-unsubscribed", async (t) => {
 
 test("autounsub - can break to unsub", async (t) => {
   const ns = await NatsServer.start(wsConfig());
-  const nc = await connect({ port: ns.websocket, ws: true });
+  const nc = await connect({ servers: `ws://127.0.0.1:${ns.websocket}` });
 
   const subj = createInbox();
   const sub = nc.subscribe(subj, { max: 20 });
@@ -93,7 +93,7 @@ test("autounsub - can break to unsub", async (t) => {
 
 test("autounsub - can change auto-unsub to a higher value", async (t) => {
   const ns = await NatsServer.start(wsConfig());
-  const nc = await connect({ port: ns.websocket, ws: true });
+  const nc = await connect({ servers: `ws://127.0.0.1:${ns.websocket}` });
 
   const subj = createInbox();
   const sub = nc.subscribe(subj, { max: 1 });
@@ -112,7 +112,7 @@ test("autounsub - request receives expected count with multiple helpers", async 
   t,
 ) => {
   const ns = await NatsServer.start(wsConfig());
-  const nc = await connect({ port: ns.websocket, ws: true });
+  const nc = await connect({ servers: `ws://127.0.0.1:${ns.websocket}` });
 
   const subj = createInbox();
 
@@ -143,7 +143,7 @@ test("autounsub - manual request receives expected count with multiple helpers",
   t,
 ) => {
   const ns = await NatsServer.start(wsConfig());
-  const nc = await connect({ port: ns.websocket, ws: true });
+  const nc = await connect({ servers: `ws://127.0.0.1:${ns.websocket}` });
 
   const subj = createInbox();
   const lock = Lock(5);
@@ -169,7 +169,7 @@ test("autounsub - manual request receives expected count with multiple helpers",
 
 test("autounsub - check subscription leaks", async (t) => {
   const ns = await NatsServer.start(wsConfig());
-  const nc = await connect({ port: ns.websocket, ws: true });
+  const nc = await connect({ servers: `ws://127.0.0.1:${ns.websocket}` });
 
   let subj = createInbox();
   let sub = nc.subscribe(subj);
@@ -181,7 +181,7 @@ test("autounsub - check subscription leaks", async (t) => {
 
 test("autounsub - check request leaks", async (t) => {
   const ns = await NatsServer.start(wsConfig());
-  const nc = await connect({ port: ns.websocket, ws: true });
+  const nc = await connect({ servers: `ws://127.0.0.1:${ns.websocket}` });
 
   let subj = createInbox();
 
@@ -219,7 +219,7 @@ test("autounsub - check request leaks", async (t) => {
 
 test("autounsub - check cancelled request leaks", async (t) => {
   const ns = await NatsServer.start(wsConfig());
-  const nc = await connect({ port: ns.websocket, ws: true });
+  const nc = await connect({ servers: `ws://127.0.0.1:${ns.websocket}` });
 
   let subj = createInbox();
 

--- a/test/basics.js
+++ b/test/basics.js
@@ -25,7 +25,7 @@ const { NatsServer, wsConfig, tlsConfig } = require("./helpers/launcher");
 
 test("basics - connect", async (t) => {
   const ns = await NatsServer.start(wsConfig());
-  const nc = await connect({ port: ns.websocket, ws: true });
+  const nc = await connect({ servers: `ws://127.0.0.1:${ns.websocket}` });
   await nc.flush();
   await nc.close();
   await ns.stop();
@@ -35,7 +35,6 @@ test("basics - connect", async (t) => {
 test("basics - tls connect", async (t) => {
   const conf = {
     websocket: {
-      no_tls: true,
       port: -1,
       tls: tlsConfig(),
     },
@@ -50,7 +49,7 @@ test("basics - tls connect", async (t) => {
 
 test("basics - publish", async (t) => {
   const ns = await NatsServer.start(wsConfig());
-  const nc = await connect({ port: ns.websocket, ws: true });
+  const nc = await connect({ servers: `ws://127.0.0.1:${ns.websocket}` });
   nc.publish(createInbox());
   await nc.flush();
   await nc.close();
@@ -61,7 +60,7 @@ test("basics - publish", async (t) => {
 test("basics - no publish without subject", async (t) => {
   t.plan(1);
   const ns = await NatsServer.start(wsConfig());
-  const nc = await connect({ port: ns.websocket, ws: true });
+  const nc = await connect({ servers: `ws://127.0.0.1:${ns.websocket}` });
   try {
     nc.publish("");
     fail("should not be able to publish without a subject");
@@ -77,7 +76,7 @@ test("basics - pubsub", async (t) => {
   t.plan(1);
   const ns = await NatsServer.start(wsConfig());
   const subj = createInbox();
-  const nc = await connect({ port: ns.websocket, ws: true });
+  const nc = await connect({ servers: `ws://127.0.0.1:${ns.websocket}` });
   const sub = nc.subscribe(subj);
   const iter = (async () => {
     for await (const m of sub) {
@@ -96,7 +95,7 @@ test("basics - subscribe and unsubscribe", async (t) => {
   t.plan(12);
   const ns = await NatsServer.start(wsConfig());
   const subj = createInbox();
-  const nc = await connect({ port: ns.websocket, ws: true });
+  const nc = await connect({ servers: `ws://127.0.0.1:${ns.websocket}` });
   const sub = nc.subscribe(subj, { max: 1000, queue: "aaa" });
 
   // check the subscription
@@ -132,7 +131,7 @@ test("basics - subscribe and unsubscribe", async (t) => {
 test("basics - subscriptions iterate", async (t) => {
   const ns = await NatsServer.start(wsConfig());
   const lock = Lock();
-  const nc = await connect({ port: ns.websocket, ws: true });
+  const nc = await connect({ servers: `ws://127.0.0.1:${ns.websocket}` });
   const subj = createInbox();
   const sub = nc.subscribe(subj);
   const _ = (async () => {
@@ -150,7 +149,7 @@ test("basics - subscriptions iterate", async (t) => {
 
 test("basics - subscriptions pass exact subject to cb", async (t) => {
   const ns = await NatsServer.start(wsConfig());
-  const nc = await connect({ port: ns.websocket, ws: true });
+  const nc = await connect({ servers: `ws://127.0.0.1:${ns.websocket}` });
 
   const s = createInbox();
   const subj = `${s}.foo.bar.baz`;
@@ -172,7 +171,7 @@ test("basics - subscriptions pass exact subject to cb", async (t) => {
 
 test("basics - subscribe returns Subscription", async (t) => {
   const ns = await NatsServer.start(wsConfig());
-  const nc = await connect({ port: ns.websocket, ws: true });
+  const nc = await connect({ servers: `ws://127.0.0.1:${ns.websocket}` });
 
   const subj = createInbox();
   const sub = nc.subscribe(subj);
@@ -190,7 +189,7 @@ test("basics - subscribe returns Subscription", async (t) => {
 
 test("basics - wildcard subscriptions", async (t) => {
   const ns = await NatsServer.start(wsConfig());
-  const nc = await connect({ port: ns.websocket, ws: true });
+  const nc = await connect({ servers: `ws://127.0.0.1:${ns.websocket}` });
 
   const single = 3;
   const partial = 2;
@@ -220,7 +219,7 @@ test("basics - wildcard subscriptions", async (t) => {
 
 test("basics - correct data in message", async (t) => {
   const ns = await NatsServer.start(wsConfig());
-  const nc = await connect({ port: ns.websocket, ws: true });
+  const nc = await connect({ servers: `ws://127.0.0.1:${ns.websocket}` });
 
   const sc = StringCodec();
   const subj = createInbox();
@@ -244,7 +243,7 @@ test("basics - correct data in message", async (t) => {
 
 test("basics - correct reply in message", async (t) => {
   const ns = await NatsServer.start(wsConfig());
-  const nc = await connect({ port: ns.websocket, ws: true });
+  const nc = await connect({ servers: `ws://127.0.0.1:${ns.websocket}` });
 
   const s = createInbox();
   const r = createInbox();
@@ -265,7 +264,7 @@ test("basics - correct reply in message", async (t) => {
 
 test("basics - respond returns false if no reply subject set", async (t) => {
   const ns = await NatsServer.start(wsConfig());
-  const nc = await connect({ port: ns.websocket, ws: true });
+  const nc = await connect({ servers: `ws://127.0.0.1:${ns.websocket}` });
 
   let s = createInbox();
   const dr = deferred();
@@ -285,7 +284,7 @@ test("basics - respond returns false if no reply subject set", async (t) => {
 
 test("basics - closed cannot subscribe", async (t) => {
   const ns = await NatsServer.start(wsConfig());
-  const nc = await connect({ port: ns.websocket, ws: true });
+  const nc = await connect({ servers: `ws://127.0.0.1:${ns.websocket}` });
   await nc.close();
   await ns.stop();
 
@@ -301,7 +300,7 @@ test("basics - closed cannot subscribe", async (t) => {
 
 test("basics - close cannot request", async (t) => {
   const ns = await NatsServer.start(wsConfig());
-  const nc = await connect({ port: ns.websocket, ws: true });
+  const nc = await connect({ servers: `ws://127.0.0.1:${ns.websocket}` });
   await nc.close();
   await ns.stop();
 
@@ -317,7 +316,7 @@ test("basics - close cannot request", async (t) => {
 
 test("basics - flush returns promise", async (t) => {
   const ns = await NatsServer.start(wsConfig());
-  const nc = await connect({ port: ns.websocket, ws: true });
+  const nc = await connect({ servers: `ws://127.0.0.1:${ns.websocket}` });
 
   let p = nc.flush();
   if (!p) {
@@ -331,7 +330,7 @@ test("basics - flush returns promise", async (t) => {
 
 test("basics - unsubscribe after close", async (t) => {
   const ns = await NatsServer.start(wsConfig());
-  const nc = await connect({ port: ns.websocket, ws: true });
+  const nc = await connect({ servers: `ws://127.0.0.1:${ns.websocket}` });
 
   let sub = nc.subscribe(createInbox());
   await nc.close();
@@ -343,7 +342,7 @@ test("basics - unsubscribe after close", async (t) => {
 
 test("basics - unsubscribe stops messages", async (t) => {
   const ns = await NatsServer.start(wsConfig());
-  const nc = await connect({ port: ns.websocket, ws: true });
+  const nc = await connect({ servers: `ws://127.0.0.1:${ns.websocket}` });
 
   const subj = createInbox();
   // in this case we use a callback otherwise messages are buffered.
@@ -365,7 +364,7 @@ test("basics - unsubscribe stops messages", async (t) => {
 
 test("basics - request", async (t) => {
   const ns = await NatsServer.start(wsConfig());
-  const nc = await connect({ port: ns.websocket, ws: true });
+  const nc = await connect({ servers: `ws://127.0.0.1:${ns.websocket}` });
 
   const sc = StringCodec();
   const s = createInbox();
@@ -383,7 +382,7 @@ test("basics - request", async (t) => {
 
 test("basics - request timeout", async (t) => {
   const ns = await NatsServer.start(wsConfig());
-  const nc = await connect({ port: ns.websocket, ws: true });
+  const nc = await connect({ servers: `ws://127.0.0.1:${ns.websocket}` });
 
   const s = createInbox();
   const lock = Lock();
@@ -404,7 +403,7 @@ test("basics - request timeout", async (t) => {
 
 test("basics - request cancel rejects", async (t) => {
   const ns = await NatsServer.start(wsConfig());
-  const nc = await connect({ port: ns.websocket, ws: true });
+  const nc = await connect({ servers: `ws://127.0.0.1:${ns.websocket}` });
 
   const s = createInbox();
   const lock = Lock();
@@ -428,7 +427,7 @@ test("basics - request cancel rejects", async (t) => {
 
 test("basics - subscription with timeout", async (t) => {
   const ns = await NatsServer.start(wsConfig());
-  const nc = await connect({ port: ns.websocket, ws: true });
+  const nc = await connect({ servers: `ws://127.0.0.1:${ns.websocket}` });
 
   const lock = Lock(1);
   const sub = nc.subscribe(createInbox(), { max: 1, timeout: 250 });
@@ -445,7 +444,7 @@ test("basics - subscription with timeout", async (t) => {
 
 test("basics - subscription expecting 2 doesn't fire timeout", async (t) => {
   const ns = await NatsServer.start(wsConfig());
-  const nc = await connect({ port: ns.websocket, ws: true });
+  const nc = await connect({ servers: `ws://127.0.0.1:${ns.websocket}` });
 
   const subj = createInbox();
   const sub = nc.subscribe(subj, { max: 2, timeout: 500 });
@@ -466,7 +465,7 @@ test("basics - subscription expecting 2 doesn't fire timeout", async (t) => {
 
 test("basics - subscription timeout auto cancels", async (t) => {
   const ns = await NatsServer.start(wsConfig());
-  const nc = await connect({ port: ns.websocket, ws: true });
+  const nc = await connect({ servers: `ws://127.0.0.1:${ns.websocket}` });
 
   const subj = createInbox();
   let c = 0;
@@ -489,7 +488,7 @@ test("basics - subscription timeout auto cancels", async (t) => {
 
 test("basics - no mux requests create normal subs", async (t) => {
   const ns = await NatsServer.start(wsConfig());
-  const nc = await connect({ port: ns.websocket, ws: true });
+  const nc = await connect({ servers: `ws://127.0.0.1:${ns.websocket}` });
 
   const _ = nc.request(createInbox(), Empty, { timeout: 1000, noMux: true });
   t.is(nc.protocol.subscriptions.size(), 1);
@@ -505,7 +504,7 @@ test("basics - no mux requests create normal subs", async (t) => {
 
 test("basics - no mux requests timeout", async (t) => {
   const ns = await NatsServer.start(wsConfig());
-  const nc = await connect({ port: ns.websocket, ws: true });
+  const nc = await connect({ servers: `ws://127.0.0.1:${ns.websocket}` });
 
   const lock = Lock();
   nc.request(createInbox(), Empty, { timeout: 250, noMux: true })
@@ -520,7 +519,7 @@ test("basics - no mux requests timeout", async (t) => {
 
 test("basics - no mux requests", async (t) => {
   const ns = await NatsServer.start(wsConfig());
-  const nc = await connect({ port: ns.websocket, ws: true });
+  const nc = await connect({ servers: `ws://127.0.0.1:${ns.websocket}` });
 
   const subj = createInbox();
   const sub = nc.subscribe(subj);
@@ -539,7 +538,7 @@ test("basics - no mux requests", async (t) => {
 
 test("basics - no max_payload messages", async (t) => {
   const ns = await NatsServer.start(wsConfig());
-  const nc = await connect({ port: ns.websocket, ws: true });
+  const nc = await connect({ servers: `ws://127.0.0.1:${ns.websocket}` });
 
   t.truthy(nc.protocol.info.max_payload);
   const big = new Uint8Array(nc.protocol.info.max_payload + 1);
@@ -581,7 +580,7 @@ test("basics - no max_payload messages", async (t) => {
 
 test("basics - empty message", async (t) => {
   const ns = await NatsServer.start(wsConfig());
-  const nc = await connect({ port: ns.websocket, ws: true });
+  const nc = await connect({ servers: `ws://127.0.0.1:${ns.websocket}` });
 
   const subj = createInbox();
   const mp = deferred();
@@ -603,7 +602,7 @@ test("basics - empty message", async (t) => {
 
 test("basics - subject is required", async (t) => {
   const ns = await NatsServer.start(wsConfig());
-  const nc = await connect({ port: ns.websocket, ws: true });
+  const nc = await connect({ servers: `ws://127.0.0.1:${ns.websocket}` });
 
   t.plan(2);
   t.throws(() => {
@@ -620,7 +619,7 @@ test("basics - subject is required", async (t) => {
 
 test("basics - payload is only Uint8Array", async (t) => {
   const ns = await NatsServer.start(wsConfig());
-  const nc = await connect({ port: ns.websocket, ws: true });
+  const nc = await connect({ servers: `ws://127.0.0.1:${ns.websocket}` });
 
   t.throws(() => {
     nc.publish(createInbox(), "s");
@@ -632,7 +631,7 @@ test("basics - payload is only Uint8Array", async (t) => {
 
 test("basics - disconnect reconnects", async (t) => {
   const ns = await NatsServer.start(wsConfig());
-  const nc = await connect({ port: ns.websocket, ws: true });
+  const nc = await connect({ servers: `ws://127.0.0.1:${ns.websocket}` });
 
   const lock = new Lock();
   const status = nc.status();
@@ -649,6 +648,22 @@ test("basics - disconnect reconnects", async (t) => {
 
   nc.protocol.transport.disconnect();
   await lock;
+  await nc.close();
+  await ns.stop();
+  t.pass();
+});
+
+test("basics - wss connection", async (t) => {
+  const conf = {
+    websocket: {
+      port: -1,
+      tls: tlsConfig(),
+    },
+  };
+
+  const ns = await NatsServer.start(conf);
+  const nc = await connect({ servers: `wss://127.0.0.1:${ns.websocket}` });
+  await nc.flush();
   await nc.close();
   await ns.stop();
   t.pass();

--- a/test/queues.js
+++ b/test/queues.js
@@ -22,7 +22,7 @@ const { NatsServer, wsConfig } = require("./helpers/launcher");
 
 test("queues - deliver to single queue", async (t) => {
   const ns = await NatsServer.start(wsConfig());
-  const nc = await connect({ port: ns.websocket, ws: true });
+  const nc = await connect({ servers: `ws://127.0.0.1:${ns.websocket}` });
 
   const subj = createInbox();
   const subs = [];
@@ -41,7 +41,7 @@ test("queues - deliver to single queue", async (t) => {
 
 test("queues - deliver to multiple queues", async (t) => {
   const ns = await NatsServer.start(wsConfig());
-  const nc = await connect({ port: ns.websocket, ws: true });
+  const nc = await connect({ servers: `ws://127.0.0.1:${ns.websocket}` });
 
   const subj = createInbox();
   const fn = (queue) => {
@@ -72,7 +72,7 @@ test("queues - deliver to multiple queues", async (t) => {
 
 test("queues - queues and subs independent", async (t) => {
   const ns = await NatsServer.start(wsConfig());
-  const nc = await connect({ port: ns.websocket, ws: true });
+  const nc = await connect({ servers: `ws://127.0.0.1:${ns.websocket}` });
 
   const subj = createInbox();
   const subs = [];

--- a/test/reconnect.js
+++ b/test/reconnect.js
@@ -30,8 +30,8 @@ const {
 test("reconnect - should receive when some servers are invalid", async (t) => {
   const ns = await NatsServer.start(wsConfig());
 
-  const servers = ["127.0.0.1:7", `127.0.0.1:${ns.websocket}`];
-  const nc = await connect({ servers: servers, noRandomize: true, ws: true });
+  const servers = ["ws://127.0.0.1:7", `ws://127.0.0.1:${ns.websocket}`];
+  const nc = await connect({ servers: servers, noRandomize: true });
 
   const lock = Lock(1);
   const subj = createInbox();
@@ -55,11 +55,10 @@ test("reconnect - events", async (t) => {
   const ns = await NatsServer.start(wsConfig());
 
   let nc = await connect({
-    port: ns.websocket,
+    servers: `ws://127.0.0.1:${ns.websocket}`,
     waitOnFirstConnect: true,
     reconnectTimeWait: 100,
     maxReconnectAttempts: 10,
-    ws: true,
   });
 
   let disconnects = 0;
@@ -93,9 +92,8 @@ test("reconnect - events", async (t) => {
 test("reconnect - reconnect not emitted if suppressed", async (t) => {
   const ns = await NatsServer.start(wsConfig());
   let nc = await connect({
-    port: ns.websocket,
+    servers: `ws://127.0.0.1:${ns.websocket}`,
     reconnect: false,
-    ws: true,
   });
 
   let disconnects = 0;
@@ -120,10 +118,9 @@ test("reconnect - reconnect not emitted if suppressed", async (t) => {
 test("reconnect - reconnecting after proper delay", async (t) => {
   const ns = await NatsServer.start(wsConfig());
   let nc = await connect({
-    port: ns.websocket,
+    servers: `ws://127.0.0.1:${ns.websocket}`,
     reconnectTimeWait: 500,
     maxReconnectAttempts: 1,
-    ws: true,
   });
   // @ts-ignore
   const serverLastConnect = nc.protocol.servers.getCurrentServer().lastConnect;
@@ -148,10 +145,9 @@ test("reconnect - reconnecting after proper delay", async (t) => {
 test("reconnect - indefinite reconnects", async (t) => {
   let ns = await NatsServer.start(wsConfig());
   let nc = await connect({
-    port: ns.websocket,
+    servers: `ws://127.0.0.1:${ns.websocket}`,
     reconnectTimeWait: 100,
     maxReconnectAttempts: -1,
-    ws: true,
   });
 
   let disconnects = 0;
@@ -202,17 +198,15 @@ test("reconnect - jitter", async (t) => {
 
   let hasDefaultFn;
   let dc = await connect({
-    port: ns.websocket,
+    servers: `ws://127.0.0.1:${ns.websocket}`,
     reconnect: false,
-    ws: true,
   });
   hasDefaultFn = typeof dc.options.reconnectDelayHandler === "function";
 
   let nc = await connect({
-    port: ns.websocket,
+    servers: `ws://127.0.0.1:${ns.websocket}`,
     maxReconnectAttempts: 1,
     reconnectDelayHandler: h,
-    ws: true,
   });
 
   await ns.stop();
@@ -225,10 +219,9 @@ test("reconnect - jitter", async (t) => {
 test("reconnect - internal disconnect forces reconnect", async (t) => {
   const ns = await NatsServer.start(wsConfig());
   const nc = await connect({
-    port: ns.websocket,
+    servers: `ws://127.0.0.1:${ns.websocket}`,
     reconnect: true,
     reconnectTimeWait: 200,
-    ws: true,
   });
 
   let stale = false;

--- a/test/urlparse.js
+++ b/test/urlparse.js
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2018-2020 The NATS Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+const test = require("ava");
+const { urlParseFn } = require("../build/wst/connect.js");
+
+test("url - parse", (t) => {
+  const u = [
+    { in: "foo", expect: "wss://foo:443/" },
+    { in: "foo:100", expect: "wss://foo:100/" },
+    { in: "foo/", expect: "wss://foo:443/" },
+    { in: "foo/hello", expect: "wss://foo:443/hello" },
+    { in: "foo:100/hello", expect: "wss://foo:100/hello" },
+    { in: "foo/hello?one=two", expect: "wss://foo:443/hello?one=two" },
+    { in: "foo:100/hello?one=two", expect: "wss://foo:100/hello?one=two" },
+    { in: "nats://foo", expect: "ws://foo:80/" },
+    { in: "tls://foo", expect: "wss://foo:443/" },
+    { in: "ws://foo", expect: "ws://foo:80/" },
+    { in: "ws://foo:100", expect: "ws://foo:100/" },
+    {
+      in: "[2001:db8:1f70::999:de8:7648:6e8]",
+      expect: "wss://[2001:db8:1f70:0:999:de8:7648:6e8]:443/",
+    },
+    {
+      in: "[2001:db8:1f70::999:de8:7648:6e8]:100",
+      expect: "wss://[2001:db8:1f70:0:999:de8:7648:6e8]:100/",
+    },
+  ];
+
+  t.plan(u.length);
+
+  u.forEach((tc) => {
+    const out = urlParseFn(tc.in);
+    t.is(out, tc.expect, `test ${tc.in}`);
+  });
+});


### PR DESCRIPTION
- [BREAKING] removed `ws` option, non-wss servers can be specified using `ws://host:port`
- Added support for full websockets URLs, paths, protocols, default ports, etc are honored.
FIX #45 