### PR TITLE
update nats-base-client dependencies to v1.0.0-13

### DIFF
--- a/.github/workflows/natsws.yml
+++ b/.github/workflows/natsws.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Use Deno Version ${{ matrix.deno-version }}
         uses: denolib/setup-deno@master
         with:
-          deno-version: 1.4.6
+          deno-version: 1.6.3
       - name: Setup Go
         uses: actions/setup-go@v1
         with:

--- a/bin/cjs-fix-imports.ts
+++ b/bin/cjs-fix-imports.ts
@@ -1,3 +1,17 @@
+/*
+ * Copyright 2020-2021 The NATS Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 import { parse } from "https://deno.land/std@0.74.0/flags/mod.ts";
 import {
   basename,

--- a/bin/clone-nd.ts
+++ b/bin/clone-nd.ts
@@ -1,3 +1,17 @@
+/*
+ * Copyright 2020-2021 The NATS Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 import { parse } from "https://deno.land/std@0.74.0/flags/mod.ts";
 import { join, resolve } from "https://deno.land/std@0.74.0/path/mod.ts";
 

--- a/bin/consistent-deps.ts
+++ b/bin/consistent-deps.ts
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2021 The NATS Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+  extname,
+  join,
+  resolve,
+} from "https://deno.land/std@0.74.0/path/mod.ts";
+
+const importers = new Map<string, string[]>();
+
+async function getInternalReferences(fn: string): Promise<string[]> {
+  const found: string[] = [];
+
+  const data = await Deno.readFile(fn);
+  const txt = new TextDecoder().decode(data);
+  const matches = txt.matchAll(
+    /("https:\/\/raw.githubusercontent.com\/nats-io\/nats.deno\/(\S+)\/nats-base-client\/internal_mod.ts")/g,
+  );
+  for (const m of matches) {
+    found.push(m[0]);
+  }
+  return found;
+}
+
+async function check(dir: string) {
+  const r = resolve(dir);
+  await Deno.lstat(r)
+    .catch((err) => {
+      console.error(`${r} was not found`);
+      Deno.exit(1);
+    });
+
+  // find all files in the directory
+  const files: string[] = [];
+  for await (const fn of Deno.readDir(r)) {
+    const ext = extname(fn.name);
+    if (ext === ".ts" || ext === ".js") {
+      files.push(join(r, fn.name));
+    }
+  }
+
+  // check for the import in source files
+  for (const fn of files) {
+    const data = await Deno.readFile(fn);
+    const txt = new TextDecoder().decode(data);
+    const matches = txt.matchAll(
+      /("https:\/\/raw.githubusercontent.com\/nats-io\/nats.deno\/(\S+)\/nats-base-client\/internal_mod.ts")/g,
+    );
+    const lines = await getInternalReferences(fn);
+    if (lines.length > 0) {
+      importers.set(fn, lines);
+    }
+  }
+}
+
+await check("./src");
+await check("./test");
+
+// process the results looking for mismatches
+if (importers.size === 0) {
+  console.error(`nats-base-client imports not found`);
+  Deno.exit(1);
+}
+
+// expected lib
+const expected = await getInternalReferences(
+  resolve("./src/nats-base-client.ts"),
+);
+if (expected.length === 0) {
+  console.error(`nats-base-client imports not found`);
+  Deno.exit(1);
+}
+
+const errs: string[] = [];
+let first = "";
+importers.forEach((v, k) => {
+  v.forEach((vv) => {
+    if (vv !== expected[0]) {
+      errs.push(`${k}: ${vv}`);
+    }
+  });
+});
+
+if (errs.length > 0) {
+  console.error(`[ERROR] expected all nbc imports to be ${expected[0]}:`);
+  console.error(errs.join("\n"));
+  Deno.exit(1);
+} else {
+  console.info(`[OK] all nbc imports match ${expected[0]}:`);
+}

--- a/examples/bench.html
+++ b/examples/bench.html
@@ -7,7 +7,7 @@
           crossorigin="anonymous">
 </head>
 <body>
-
+<script type="module" src="./bench.js"></script>
 <div class="container">
     <h1 id="title">WS NATS Browser Performance</h1>
     <label for="server">NATS Websocket Server</label>
@@ -49,8 +49,6 @@
 <div class="container">
     <pre id="results"></pre>
 </div>
-
-<script type="module" src="./bench.js"></script>
 
 </body>
 </html>

--- a/examples/wss.html
+++ b/examples/wss.html
@@ -21,9 +21,9 @@
   }
 
   const init = async function () {
-    // create a connection to a wss server
-    const nc = await connect({ servers: 'localhost:9222', ws: false })
-    .then(async () => {
+    try {
+      // create a connection to a wss server
+      const nc = await connect({ servers: 'wss://localhost:9222' });
       addEntry('connected!');
       await nc.flush();
       addEntry('did a round-trip to the server');
@@ -31,10 +31,10 @@
       // close the connection
       await nc.close();
       addEntry('closed the connection');
-    })
-    .catch(() => {
-      addEntry(`error connecting - did you setup a wss server?`);
-    });
+    } catch(err) {
+      addEntry(`error connecting - did you setup a wss server? ${err}`);
+      console.error(err)
+    }
   }
   init();
 </script>

--- a/nats.d.ts
+++ b/nats.d.ts
@@ -167,15 +167,34 @@ export interface JwtAuth {
 
 export declare function noAuthFn(): Authenticator;
 
+/**
+ * Returns an nkey authenticator that returns a public key
+ * @param {Uint8Array | (() => Uint8Array)} seed
+ * @return {NKeyAuth}
+ */
 export declare function nkeyAuthenticator(
   seed?: Uint8Array | (() => Uint8Array),
 ): Authenticator;
 
+/**
+ * Returns a jwt authenticator. If a seed is provided, the public
+ * key, and signature are calculated. Note if a signature is provided
+ * the returned value should be a base64 encoded string.
+ *
+ * @return {JwtAuth}
+ * @param ajwt
+ * @param seed
+ */
 export declare function jwtAuthenticator(
   ajwt: string | (() => string),
   seed?: Uint8Array | (() => Uint8Array),
 ): Authenticator;
 
+/**
+ * Returns a jwt authenticator configured from the specified creds file contents.
+ * @param creds
+ * @returns {JwtAuth}
+ */
 export declare function credsAuthenticator(creds: Uint8Array): Authenticator;
 
 export declare enum ErrorCode {
@@ -253,4 +272,4 @@ export interface Codec<T> {
 
 export declare function StringCodec(): Codec<string>;
 
-export declare function JSONCodec(): Codec<any>;
+export declare function JSONCodec(): Codec<unknown>;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "nats.ws",
-  "version": "1.0.0-112",
+  "version": "1.0.0-115",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nats.ws",
-  "version": "1.0.0-114",
+  "version": "1.0.0-115",
   "description": "WebSocket NATS client",
   "main": "nats.mjs",
   "types": "nats.d.ts",
@@ -13,7 +13,7 @@
   ],
   "scripts": {
     "setup": "curl -fsSL https://deno.land/x/install/install.sh | sh",
-    "build": "deno run --allow-all --unstable --reload src/mod.ts && deno bundle --unstable src/mod.ts ./nats.mjs",
+    "build": "deno run --allow-all --unstable --reload src/mod.ts && deno bundle --log-level info --unstable src/mod.ts ./nats.mjs",
     "prepack": "npm run build",
     "fmt": "deno fmt src/*.ts examples/*.js test/*.js test/*/*.js",
     "start-tls-nats": "cd examples && ../nats-server -c tls.conf",
@@ -29,7 +29,8 @@
     "clean": "rm -Rf ./nats.mjs ./build ./.deps ./nats-base-client ./cjs-wst",
     "stage": "npm run clean && npm run clone-nbc && npm run cjs-nbc && npm run cjs-wst && rm -Rf ./.deps/ && npm run build-cjs && rm -Rf ./wst",
     "ava": "nyc ava --verbose -T 60000",
-    "test": "npm run stage && npm run ava",
+    "test": "npm run stage && npm run check-imports && npm run ava",
+    "check-imports": "deno run --allow-all bin/consistent-deps.ts",
     "debug-test": "node node_modules/.bin/ava --verbose -T 6500000 --match"
   },
   "devDependencies": {

--- a/src/connect.ts
+++ b/src/connect.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 The NATS Authors
+ * Copyright 2020-2021 The NATS Authors
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -19,11 +19,11 @@ import {
   setTransportFactory,
   setUrlParseFn,
   Transport,
-} from "./nats-base-client.ts";
+} from "https://raw.githubusercontent.com/nats-io/nats.deno/v1.0.0-13/nats-base-client/internal_mod.ts";
 
 import { WsTransport } from "./ws_transport.ts";
 
-export function urlParseFn(u: string): string {
+export function wsUrlParseFn(u: string): string {
   const ut = /^(.*:\/\/)(.*)/;
   if (!ut.test(u)) {
     u = `https://${u}`;
@@ -37,9 +37,9 @@ export function urlParseFn(u: string): string {
 
   let protocol;
   let port;
-  let host = url.hostname;
-  let path = url.pathname;
-  let search = url.search || "";
+  const host = url.hostname;
+  const path = url.pathname;
+  const search = url.search || "";
 
   switch (srcProto) {
     case "http:":
@@ -57,7 +57,7 @@ export function urlParseFn(u: string): string {
 }
 
 export function connect(opts: ConnectionOptions = {}): Promise<NatsConnection> {
-  setUrlParseFn(urlParseFn);
+  setUrlParseFn(wsUrlParseFn);
 
   setTransportFactory((): Transport => {
     return new WsTransport();

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 The NATS Authors
+ * Copyright 2020-2021 The NATS Authors
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -12,5 +12,5 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export * from "./nats-base-client.ts";
+export * from "https://raw.githubusercontent.com/nats-io/nats.deno/v1.0.0-13/nats-base-client/internal_mod.ts";
 export { connect } from "./connect.ts";

--- a/src/nats-base-client.ts
+++ b/src/nats-base-client.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 The NATS Authors
+ * Copyright 2020-2021 The NATS Authors
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -12,4 +12,5 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export * from "https://raw.githubusercontent.com/nats-io/nats.deno/v1.0.0-12/nats-base-client/internal_mod.ts";
+// this import here to drive the build system
+export * from "https://raw.githubusercontent.com/nats-io/nats.deno/v1.0.0-13/nats-base-client/internal_mod.ts";

--- a/test/auth.js
+++ b/test/auth.js
@@ -102,8 +102,10 @@ test("auth - sub permissions", async (t) => {
   });
 
   const sub = nc.subscribe("foo");
-  (async (t) => {
-    for await (const m of sub) {}
+  (async () => {
+    for await (const m of sub) {
+      // ignored
+    }
   })().catch((err) => {
     lock.unlock();
     t.is(err.code, ErrorCode.PERMISSIONS_VIOLATION);

--- a/test/helpers/launcher.d.ts
+++ b/test/helpers/launcher.d.ts
@@ -32,6 +32,6 @@ export interface NatsServer extends PortInfo {
   restart(): Promise<NatsServer>;
   getLog(): string;
   stop(): Promise<void>;
-  signal(s: ("KILL" | "QUIT" | "STOP" | "REOPEN" | "RELOAD" | "LDM"));
+  signal(s: ("KILL" | "QUIT" | "STOP" | "REOPEN" | "RELOAD" | "LDM")): void;
   varz(): Promise<any>;
 }

--- a/test/helpers/launcher.js
+++ b/test/helpers/launcher.js
@@ -190,7 +190,6 @@ exports.NatsServer = class NatsServer {
   signal(signal) {
     const sn = ServerSignals.get(signal);
     this.process.kill(sn ? sn : signal);
-    return Promise.resolve();
   }
 
   async varz() {

--- a/test/reconnect.js
+++ b/test/reconnect.js
@@ -153,7 +153,7 @@ test("reconnect - indefinite reconnects", async (t) => {
   let disconnects = 0;
   let reconnects = 0;
   let reconnect = false;
-  (async (t) => {
+  (async () => {
     for await (const e of nc.status()) {
       switch (e.type) {
         case Events.DISCONNECT:

--- a/test/urlparse.js
+++ b/test/urlparse.js
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 const test = require("ava");
-const { urlParseFn } = require("../build/wst/connect.js");
+const { wsUrlParseFn } = require("../build/wst/connect.js");
 
 test("url - parse", (t) => {
   const u = [
@@ -41,7 +41,7 @@ test("url - parse", (t) => {
   t.plan(u.length);
 
   u.forEach((tc) => {
-    const out = urlParseFn(tc.in);
+    const out = wsUrlParseFn(tc.in);
     t.is(out, tc.expect, `test ${tc.in}`);
   });
 });


### PR DESCRIPTION
- [update] changes upstream enable current deno bundling to emit safari compatible code (no initializers on class definitions or static instances).
- [change] referenced nats-base-client code directly as the current bundler is still not able to properly emit an ES bundle when locally re-exporting dependencies from a different library.
-  [add] added a test assertion that imports for nats-base-client are from the same version, as now references from the library appear more than once.