### PR TITLE
FIX #61 - connection state was resolved too early

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nats.ws",
-  "version": "1.0.0-116",
+  "version": "1.0.0-117",
   "description": "WebSocket NATS client",
   "main": "nats.mjs",
   "types": "nats.d.ts",

--- a/src/ws_transport.ts
+++ b/src/ws_transport.ts
@@ -16,21 +16,22 @@ import type {
   ConnectionOptions,
   Deferred,
   Server,
-  Transport,
   ServerInfo,
+  Transport,
 } from "https://raw.githubusercontent.com/nats-io/nats.deno/v1.0.0-13/nats-base-client/internal_mod.ts";
 import {
+  checkOptions,
+  DataBuffer,
   deferred,
   delay,
   ErrorCode,
-  NatsError,
-  render,
-  DataBuffer,
   extractProtocolMessage,
   INFO,
+  NatsError,
+  render,
 } from "https://raw.githubusercontent.com/nats-io/nats.deno/v1.0.0-13/nats-base-client/internal_mod.ts";
 
-const VERSION = "1.0.0-116";
+const VERSION = "1.0.0-117";
 const LANG = "nats.ws";
 
 export class WsTransport implements Transport {
@@ -44,7 +45,7 @@ export class WsTransport implements Transport {
   private options!: ConnectionOptions;
   socketClosed: boolean;
   encrypted: boolean;
-  peeked: boolean
+  peeked: boolean;
 
   yields: Uint8Array[] = [];
   signal: Deferred<void> = deferred<void>();
@@ -60,12 +61,18 @@ export class WsTransport implements Transport {
     this.peeked = false;
   }
 
-  async connect(
+  connect(
     server: Server,
     options: ConnectionOptions,
   ): Promise<void> {
     const connected = false;
     const connLock = deferred<void>();
+
+    // ws client doesn't support TLS setting
+    if (options.tls) {
+      connLock.reject(new NatsError("tls", ErrorCode.INVALID_OPTION));
+      return connLock;
+    }
 
     this.options = options;
     const u = server.src;
@@ -74,32 +81,34 @@ export class WsTransport implements Transport {
     this.socket.binaryType = "arraybuffer";
 
     this.socket.onopen = () => {
-      this.connected = true;
+      // we don't do anything here...
     };
 
     this.socket.onmessage = (me: MessageEvent) => {
       this.yields.push(new Uint8Array(me.data));
       if (this.peeked) {
         this.signal.resolve();
-        return
+        return;
       }
       const t = DataBuffer.concat(...this.yields);
       const pm = extractProtocolMessage(t);
       if (pm) {
         const m = INFO.exec(pm);
         if (!m) {
+          if (options.debug) {
+            console.error("!!!", render(t));
+          }
           connLock.reject(new Error("unexpected response from server"));
           return;
         }
         try {
-          // we are going to ignore this value, just trying to parse
-          JSON.parse(m[1]);
-          // if here we parsed something
+          const info = JSON.parse(m[1]) as ServerInfo;
+          checkOptions(info, this.options);
           this.peeked = true;
           this.connected = true;
           this.signal.resolve();
           connLock.resolve();
-        } catch(err) {
+        } catch (err) {
           connLock.reject(err);
           return;
         }
@@ -129,7 +138,6 @@ export class WsTransport implements Transport {
     };
     return connLock;
   }
-
 
   disconnect(): void {
     this._closed(undefined, true);

--- a/test/basics.js
+++ b/test/basics.js
@@ -13,8 +13,9 @@
  * limitations under the License.
  */
 
+
 const test = require("ava");
-const { connect, ErrorCode, createInbox, StringCodec, Empty, Events } = require(
+const { connect, ErrorCode, createInbox, StringCodec, Empty } = require(
   "./index",
 );
 const { deferred, delay } = require(
@@ -665,6 +666,24 @@ test("basics - wss connection", async (t) => {
   const nc = await connect({ servers: `wss://127.0.0.1:${ns.websocket}` });
   await nc.flush();
   await nc.close();
+  await ns.stop();
+  t.pass();
+});
+
+test("basics - wsnats doesn't support tls options", async (t) => {
+  const conf = {
+    websocket: {
+      port: -1,
+      tls: tlsConfig(),
+    },
+  };
+  const ns = await NatsServer.start(conf);
+  try {
+    await connect({ servers: `wss://127.0.0.1:${ns.websocket}`, tls: {} });
+    t.fail(`should have failed with ${ErrorCode.INVALID_OPTION}`);
+  } catch(err) {
+    t.is(err.code, ErrorCode.INVALID_OPTION)
+  }
   await ns.stop();
   t.pass();
 });


### PR DESCRIPTION
- [fix] added peek on connect before resolving the connection
- [fix] added check to options specified options that require matching with the server capabilities before resolving the connection
- [feat] added check that `tls` options are not set on the ws client as they cannot be honored (the connection is wss or ws).