### PR TITLE
use `class` instead of `interface` for NatsError declaration

### DIFF
--- a/nats.d.ts
+++ b/nats.d.ts
@@ -216,7 +216,7 @@ export enum ErrorCode {
   PERMISSIONS_VIOLATION = "PERMISSIONS_VIOLATION",
 }
 
-export declare interface NatsError extends Error {
+export declare class NatsError extends Error {
   name: string;
   message: string;
   code: string;

--- a/test/index.d.ts
+++ b/test/index.d.ts
@@ -218,7 +218,7 @@ export declare const ErrorCode: Readonly<{
   PERMISSIONS_VIOLATION: string;
 }>;
 
-export declare interface NatsError extends Error {
+export declare class NatsError extends Error {
   name: string;
   message: string;
   code: string;


### PR DESCRIPTION
This allows users to use NatsError with `instanceof`:

```ts
if (e instanceof NatsError) {
    /** handle */
}
```