### PR TITLE
nbc handling of request exception rejecting rather than throwing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nats.ws",
-  "version": "1.3.1-2",
+  "version": "1.4.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "nats.ws",
-      "version": "1.3.1-2",
+      "version": "1.4.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/node": "^16.10.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nats.ws",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "WebSocket NATS client",
   "main": "nats.cjs",
   "module": "nats.js",

--- a/src/connect.ts
+++ b/src/connect.ts
@@ -19,7 +19,7 @@ import {
   setTransportFactory,
   Transport,
   TransportFactory,
-} from "https://raw.githubusercontent.com/nats-io/nats.deno/request-assert/nats-base-client/internal_mod.ts";
+} from "https://raw.githubusercontent.com/nats-io/nats.deno/v1.3.1/nats-base-client/internal_mod.ts";
 
 import { WsTransport } from "./ws_transport.ts";
 

--- a/src/connect.ts
+++ b/src/connect.ts
@@ -19,7 +19,7 @@ import {
   setTransportFactory,
   Transport,
   TransportFactory,
-} from "https://raw.githubusercontent.com/nats-io/nats.deno/v1.3.0/nats-base-client/internal_mod.ts";
+} from "https://raw.githubusercontent.com/nats-io/nats.deno/request-assert/nats-base-client/internal_mod.ts";
 
 import { WsTransport } from "./ws_transport.ts";
 

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -12,5 +12,5 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export * from "https://raw.githubusercontent.com/nats-io/nats.deno/request-assert/nats-base-client/mod.ts";
+export * from "https://raw.githubusercontent.com/nats-io/nats.deno/v1.3.1/nats-base-client/mod.ts";
 export { connect } from "./connect.ts";

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -12,5 +12,5 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export * from "https://raw.githubusercontent.com/nats-io/nats.deno/v1.3.0/nats-base-client/mod.ts";
+export * from "https://raw.githubusercontent.com/nats-io/nats.deno/request-assert/nats-base-client/mod.ts";
 export { connect } from "./connect.ts";

--- a/src/nats-base-client.ts
+++ b/src/nats-base-client.ts
@@ -13,4 +13,4 @@
  * limitations under the License.
  */
 // this import here to drive the build system
-export * from "https://raw.githubusercontent.com/nats-io/nats.deno/v1.3.0/nats-base-client/internal_mod.ts";
+export * from "https://raw.githubusercontent.com/nats-io/nats.deno/request-assert/nats-base-client/internal_mod.ts";

--- a/src/nats-base-client.ts
+++ b/src/nats-base-client.ts
@@ -13,4 +13,4 @@
  * limitations under the License.
  */
 // this import here to drive the build system
-export * from "https://raw.githubusercontent.com/nats-io/nats.deno/request-assert/nats-base-client/internal_mod.ts";
+export * from "https://raw.githubusercontent.com/nats-io/nats.deno/v1.3.1/nats-base-client/internal_mod.ts";

--- a/src/ws_transport.ts
+++ b/src/ws_transport.ts
@@ -19,7 +19,7 @@ import type {
   Server,
   ServerInfo,
   Transport,
-} from "https://raw.githubusercontent.com/nats-io/nats.deno/v1.3.0/nats-base-client/internal_mod.ts";
+} from "https://raw.githubusercontent.com/nats-io/nats.deno/request-assert/nats-base-client/internal_mod.ts";
 import {
   checkOptions,
   DataBuffer,
@@ -30,9 +30,9 @@ import {
   INFO,
   NatsError,
   render,
-} from "https://raw.githubusercontent.com/nats-io/nats.deno/v1.3.0/nats-base-client/internal_mod.ts";
+} from "https://raw.githubusercontent.com/nats-io/nats.deno/request-assert/nats-base-client/internal_mod.ts";
 
-const VERSION = "1.4.0";
+const VERSION = "1.4.1";
 const LANG = "nats.ws";
 
 export class WsTransport implements Transport {

--- a/src/ws_transport.ts
+++ b/src/ws_transport.ts
@@ -19,7 +19,7 @@ import type {
   Server,
   ServerInfo,
   Transport,
-} from "https://raw.githubusercontent.com/nats-io/nats.deno/request-assert/nats-base-client/internal_mod.ts";
+} from "https://raw.githubusercontent.com/nats-io/nats.deno/v1.3.1/nats-base-client/internal_mod.ts";
 import {
   checkOptions,
   DataBuffer,
@@ -30,7 +30,7 @@ import {
   INFO,
   NatsError,
   render,
-} from "https://raw.githubusercontent.com/nats-io/nats.deno/request-assert/nats-base-client/internal_mod.ts";
+} from "https://raw.githubusercontent.com/nats-io/nats.deno/v1.3.1/nats-base-client/internal_mod.ts";
 
 const VERSION = "1.4.1";
 const LANG = "nats.ws";

--- a/test/basics.js
+++ b/test/basics.js
@@ -614,11 +614,9 @@ test("basics - subject is required", async (t) => {
     nc.publish();
   }, { code: ErrorCode.BadSubject });
 
-  try {
-    await nc.request();
-  } catch (err) {
-    t.is(err.message, "BAD_SUBJECT");
-  }
+  await nc.request().catch((err) => {
+    t.is(err.code, ErrorCode.BadSubject);
+  });
 
   await nc.close();
   await ns.stop();


### PR DESCRIPTION
undid a fix on a test that hid an actual issue where the request, which returns a promise was also throwing - on deno this doesn't happen and the promise is rejected properly - on node because the function is not async, it actually does throw instead of rejecting the request.