### PR TITLE
1.10.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,12 @@
 {
   "name": "nats.ws",
-  "version": "1.10.0-2",
+  "version": "1.10.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "1.10.0-2",
+      "name": "nats.ws",
+      "version": "1.10.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/node": "^18.0.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nats.ws",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "description": "WebSocket NATS client",
   "main": "./cjs/nats.js",
   "module": "./esm/nats.js",

--- a/src/connect.ts
+++ b/src/connect.ts
@@ -19,7 +19,7 @@ import {
   setTransportFactory,
   Transport,
   TransportFactory,
-} from "https://raw.githubusercontent.com/nats-io/nats.deno/v1.9.0/nats-base-client/internal_mod.ts";
+} from "https://raw.githubusercontent.com/nats-io/nats.deno/v1.9.2/nats-base-client/internal_mod.ts";
 
 import { WsTransport } from "./ws_transport.ts";
 

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -12,5 +12,5 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export * from "https://raw.githubusercontent.com/nats-io/nats.deno/v1.9.0/nats-base-client/mod.ts";
+export * from "https://raw.githubusercontent.com/nats-io/nats.deno/v1.9.2/nats-base-client/mod.ts";
 export { connect } from "./connect.ts";

--- a/src/nats-base-client.ts
+++ b/src/nats-base-client.ts
@@ -13,4 +13,4 @@
  * limitations under the License.
  */
 // this import here to drive the build system
-export * from "https://raw.githubusercontent.com/nats-io/nats.deno/v1.9.0/nats-base-client/internal_mod.ts";
+export * from "https://raw.githubusercontent.com/nats-io/nats.deno/v1.9.2/nats-base-client/internal_mod.ts";

--- a/src/ws_transport.ts
+++ b/src/ws_transport.ts
@@ -19,7 +19,7 @@ import type {
   Server,
   ServerInfo,
   Transport,
-} from "https://raw.githubusercontent.com/nats-io/nats.deno/v1.9.0/nats-base-client/internal_mod.ts";
+} from "https://raw.githubusercontent.com/nats-io/nats.deno/v1.9.2/nats-base-client/internal_mod.ts";
 import {
   checkOptions,
   DataBuffer,
@@ -30,9 +30,9 @@ import {
   INFO,
   NatsError,
   render,
-} from "https://raw.githubusercontent.com/nats-io/nats.deno/v1.9.0/nats-base-client/internal_mod.ts";
+} from "https://raw.githubusercontent.com/nats-io/nats.deno/v1.9.2/nats-base-client/internal_mod.ts";
 
-const VERSION = "1.10.0";
+const VERSION = "1.10.1";
 const LANG = "nats.ws";
 
 export type WsSocketFactory = (u: string, opts: ConnectionOptions) => Promise<{

--- a/test/auth.js
+++ b/test/auth.js
@@ -343,7 +343,7 @@ test("auth - custom error", async (t) => {
   ).then(() => {
     t.fail("shouldn't have connected");
   }).catch((err) => {
-    t.is(err.code, ErrorCode.BadAuthentication);
+    t.is(err.message, "user code exploded");
   });
   await ns.stop();
 });


### PR DESCRIPTION
[BUMP] nbc to 1.9.2
[FIX] test to verify connect exception is returned as is [FIX] tls tests that now get rejected because of certificate names trust issues to point to demo.nats.io:8443