### PR TITLE
Updated developer nodes

### DIFF
--- a/developer_notes.md
+++ b/developer_notes.md
@@ -55,7 +55,7 @@ The transpilation process seems to not pick up on the right library for nats.ws.
 To work around the issue, simple insure you import from the cjs file directly:
 
 ```javascript
-import {connect} from "../node_modules/nats.ws/lib/src/mod.js"
+import {connect} from "../node_modules/nats.ws/cjs/nats.js"
 ```
 
 A simple screencast introduction to nats.ws viewed React can be found here:
@@ -75,8 +75,8 @@ If you are using an older version of the typescript compiler (for example, if yo
         "node_modules/nkeys.js/lib/nkeys.d.ts"
       ],
       "nats.ws": [
-        "node_modules/nats.ws/nats.js",
-        "node_modules/nats.ws/nats.d.ts"
+        "node_modules/nats.ws/cjs/nats.js",
+        "node_modules/nats.ws/lib/src/mod.d.ts"
       ]
     }
   }


### PR DESCRIPTION
recent repackaging changed - the library should work on current versions of the stack, but on some old ones may need additional hints 

[ci skip]