### PR TITLE
Update NATS dependencies to v1.29.2 and bump version to 1.30.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nats.ws",
-  "version": "1.30.0",
+  "version": "1.30.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nats.ws",
-      "version": "1.30.0",
+      "version": "1.30.2",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/node": "^22.10.5",
@@ -414,9 +414,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "22.10.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.5.tgz",
-      "integrity": "sha512-F8Q+SeGimwOo86fiovQh8qiXfFEh2/ocYv7tU5pJ3EXMSSxk1Joj5wefpFK2fHTf/N6HKGSxIDBT9f3gCxXPkQ==",
+      "version": "22.13.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.2.tgz",
+      "integrity": "sha512-Z+r8y3XL9ZpI2EY52YYygAFmo2/oWfNSj4BCpAXE2McAexDk8VcnBMGC9Djn9gTKt4d2T/hhXqmPzo4hfIXtTg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nats.ws",
-  "version": "1.30.1",
+  "version": "1.30.2",
   "description": "WebSocket NATS client",
   "main": "./cjs/nats.js",
   "module": "./esm/nats.js",

--- a/src/connect.ts
+++ b/src/connect.ts
@@ -19,7 +19,7 @@ import {
   setTransportFactory,
   Transport,
   TransportFactory,
-} from "https://raw.githubusercontent.com/nats-io/nats.deno/v1.29.1/nats-base-client/internal_mod.ts";
+} from "https://raw.githubusercontent.com/nats-io/nats.deno/v1.29.2/nats-base-client/internal_mod.ts";
 
 import { WsTransport } from "./ws_transport.ts";
 

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -12,6 +12,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export * from "https://raw.githubusercontent.com/nats-io/nats.deno/v1.29.1/nats-base-client/mod.ts";
-export * from "https://raw.githubusercontent.com/nats-io/nats.deno/v1.29.1/jetstream/mod.ts";
+export * from "https://raw.githubusercontent.com/nats-io/nats.deno/v1.29.2/nats-base-client/mod.ts";
+export * from "https://raw.githubusercontent.com/nats-io/nats.deno/v1.29.2/jetstream/mod.ts";
 export { connect } from "./connect.ts";

--- a/src/nats-base-client.ts
+++ b/src/nats-base-client.ts
@@ -13,4 +13,4 @@
  * limitations under the License.
  */
 // this import here to drive the build system
-export * from "https://raw.githubusercontent.com/nats-io/nats.deno/v1.29.1/nats-base-client/internal_mod.ts";
+export * from "https://raw.githubusercontent.com/nats-io/nats.deno/v1.29.2/nats-base-client/internal_mod.ts";

--- a/src/ws_transport.ts
+++ b/src/ws_transport.ts
@@ -19,7 +19,7 @@ import type {
   Server,
   ServerInfo,
   Transport,
-} from "https://raw.githubusercontent.com/nats-io/nats.deno/v1.29.1/nats-base-client/internal_mod.ts";
+} from "https://raw.githubusercontent.com/nats-io/nats.deno/v1.29.2/nats-base-client/internal_mod.ts";
 import {
   checkOptions,
   DataBuffer,
@@ -30,9 +30,9 @@ import {
   INFO,
   NatsError,
   render,
-} from "https://raw.githubusercontent.com/nats-io/nats.deno/v1.29.1/nats-base-client/internal_mod.ts";
+} from "https://raw.githubusercontent.com/nats-io/nats.deno/v1.29.2/nats-base-client/internal_mod.ts";
 
-const VERSION = "1.30.1";
+const VERSION = "1.30.2";
 const LANG = "nats.ws";
 
 export type WsSocketFactory = (u: string, opts: ConnectionOptions) => Promise<{


### PR DESCRIPTION
Upgraded NATS library references to v1.29.2 for improved stability and compatibility. Updated package version to 1.30.2 and refreshed dev dependency @types/node to v22.13.2.